### PR TITLE
WIP: TIMEOUT instead of IMMEDIATE

### DIFF
--- a/src/ssg.c
+++ b/src/ssg.c
@@ -428,7 +428,8 @@ ssg_group_id_t ssg_group_create_pmix(
     snprintf(key, 512, "ssg-%s-%d-id", proc.nspace, proc.rank);
     PMIX_INFO_CREATE(info, 1);
     flag = true;
-    PMIX_INFO_LOAD(info, PMIX_IMMEDIATE, &flag, PMIX_BOOL);
+    int wait_secs=1;
+    PMIX_INFO_LOAD(info, PMIX_TIMEOUT, &wait_secs, PMIX_INT);
     ret = PMIx_Get(&proc, key, info, 1, &val_p);
     PMIX_INFO_FREE(info, 1);
     if (ret != PMIX_SUCCESS)
@@ -2344,7 +2345,8 @@ void ssg_pmix_proc_failure_notify_fn(
     snprintf(key, 512, "ssg-%s-%d-id", source->nspace, source->rank);
     PMIX_INFO_CREATE(get_info, 1);
     flag = true;
-    PMIX_INFO_LOAD(get_info, PMIX_IMMEDIATE, &flag, PMIX_BOOL);
+    int wait_secs=1;
+    PMIX_INFO_LOAD(get_info, PMIX_TIMEOUT, &wait_secs, PMIX_INT);
     ret = PMIx_Get(source, key, get_info, 1, &val_p);
     PMIX_INFO_FREE(get_info, 1);
     if (ret != PMIX_SUCCESS)


### PR DESCRIPTION
In GitLab by @roblatham00 on Dec 1, 2020, 14:36

On summit, pmix operations would hang indefinitely unless we changed from `PMIX_IMMEDIATE` to `PMIX_TIMEOUT`.

https://github.com/openpmix/openpmix/issues/1803

Might have been fixed, but we haven't tested it yet:

https://github.com/openpmix/openpmix/pull/1877