### PR TITLE
WIP: added group hash

### DIFF
--- a/include/ssg.h
+++ b/include/ssg.h
@@ -313,6 +313,20 @@ int ssg_get_group_size(
     ssg_group_id_t group_id);
 
 /**
+ * @brief Get a hash summarizing the group.
+ * The hash changes as members join and leave, providing the
+ * caller with a simple way of detecting that two processes
+ * don't have the same view of a group.
+ *
+ * @param [in] group_id SSG group id
+ * @param [out] hash hash
+ *
+ * @return SSG_SUCCESS or error code
+ */
+int ssg_get_group_hash(
+    ssg_group_id_t group_id, uint64_t* hash);
+
+/**
  * Obtains the HG address of a member in a given SSG group.
  *
  * @param[in] group_id  SSG group ID

--- a/tests/ssg-join-leave-group.c
+++ b/tests/ssg-join-leave-group.c
@@ -158,6 +158,10 @@ int main(int argc, char *argv[])
     sret = ssg_group_join(mid, g_id, NULL, NULL);
     DIE_IF(sret != SSG_SUCCESS, "ssg_group_join");
 
+    uint64_t group_hash = 0;
+    ssg_get_group_hash(g_id, &group_hash);
+    printf("SSG group hash is %lu\n", group_hash);
+
     /* sleep for given duration to allow group time to run */
     if (opts.leave_time >= 0)
     {

--- a/tests/ssg-launch-group.c
+++ b/tests/ssg-launch-group.c
@@ -193,6 +193,10 @@ int main(int argc, char *argv[])
 #endif
     DIE_IF(g_id == SSG_GROUP_ID_INVALID, "ssg_group_create");
 
+    uint64_t group_hash = 0;
+    ssg_get_group_hash(g_id, &group_hash);
+    printf("SSG group hash is %lu\n", group_hash);
+
     /* store the gid if requested */
     if (opts.gid_file)
         ssg_group_id_store(opts.gid_file, g_id, SSG_ALL_MEMBERS);

--- a/tests/ssg-observe-group.c
+++ b/tests/ssg-observe-group.c
@@ -67,7 +67,7 @@ static void parse_args(int argc, char *argv[], int *sleep_time, const char **add
     *addr_str = argv[ndx++];
     *gid_file = argv[ndx++];
 
-    return;   
+    return;
 }
 
 int main(int argc, char *argv[])
@@ -103,6 +103,10 @@ int main(int argc, char *argv[])
     /* start observging the SSG server group */
     sret = ssg_group_observe(mid, g_id);
     DIE_IF(sret != SSG_SUCCESS, "ssg_group_observe");
+
+    uint64_t group_hash = 0;
+    ssg_get_group_hash(g_id, &group_hash);
+    printf("SSG group hash is %lu\n", group_hash);
 
     /* for now, just sleep to give observer a chance to establish connection */
     /* XXX: we could replace this with a barrier eventually */


### PR DESCRIPTION
In GitLab by @mdorier on Jan 9, 2021, 16:25

This PR adds a "group hash", computed and maintained up to date as follows:
```
hash = 0
foreach member_id in group {
    hash = xor(hash, member_id)
}
```
It is a preliminary addition to enable services/processes to check whether they have the same view of a group, and could be used in a future `ssg_group_refresh` function to issue an RDMA operation only if the hash differs.

I'm marking this PR as a WIP; it should be rebased onto master once master gets updated with the branch that adds better error codes.