### PR TITLE
bump version number and propagate to ssg.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([ssg], [0.4.5], [],[],[]) 
+AC_INIT([ssg], [0.5], [],[],[])
 AC_CONFIG_MACRO_DIR([m4])
 LT_INIT
 

--- a/maint/ssg.pc.in
+++ b/maint/ssg.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: ssg
 Description: Scalable Service Groups (SSG) interface for Mercury
-Version: 0.3
+Version: @PACKAGE_VERSION@
 URL: https://xgitlab.cels.anl.gov/sds/ssg
 Requires: margo
 Requires.private: @PMIX_PKGCONFIG@


### PR DESCRIPTION
Set version number to 0.5 in main.  Alter ssg.pc.in a little to make sure that it automatically picks up the version set in autoconf rather than a hardcoded value.