### PR TITLE
memory fixes

### DIFF
--- a/src/ssg.c
+++ b/src/ssg.c
@@ -1919,6 +1919,8 @@ int ssg_group_id_deserialize(
         return ret;
     }
 
+    free(addr_strs);
+
     /* add this group descriptor to our global table, first making sure not re-create */
     ABT_rwlock_wrlock(ssg_rt->lock);
     HASH_FIND(hh, ssg_rt->gd_table, &g_id, sizeof(ssg_group_id_t), gd_check);
@@ -1927,7 +1929,6 @@ int ssg_group_id_deserialize(
         ABT_rwlock_unlock(ssg_rt->lock);
         ssg_group_view_destroy(gd->view, NULL);
         ssg_group_descriptor_free(gd);
-        free(addr_strs);
         return SSG_ERR_GROUP_EXISTS;
     }
     HASH_ADD(hh, ssg_rt->gd_table, g_id, sizeof(ssg_group_id_t), gd);

--- a/src/swim-fd/swim-fd.c
+++ b/src/swim-fd/swim-fd.c
@@ -477,7 +477,7 @@ static void swim_shuffle_ping_target_list(
         if (list->targets[i]->swim_state.status == SWIM_MEMBER_DEAD)
         {
             list->len--;
-            memcpy(&list->targets[i], &list->targets[i+1],
+            memmove(&list->targets[i], &list->targets[i+1],
                 (list->len-i)*sizeof(*list->targets));
         }
     }

--- a/tests/ssg-launch-group.c
+++ b/tests/ssg-launch-group.c
@@ -255,6 +255,9 @@ int main(int argc, char *argv[])
     DIE_IF(ret != SSG_SUCCESS, "ssg_get_group_member_addr (%s)", ssg_strerror(ret));
     DIE_IF(member_addr == HG_ADDR_NULL, "ssg_get_group_member_addr (%s)", ssg_strerror(ret));
 
+    /* release address retrieved from ssg */
+    margo_addr_free(mid, member_addr);
+
     /* print group at each member */
     ssg_group_dump(cb_dat.gid);
     ssg_group_destroy(cb_dat.gid);


### PR DESCRIPTION
- test prog mem leak
- internal ssg mem leak
- replace memcpy with memmove for overlap safety

These issues weren't likely to harm much, but it makes make check pass cleanly with address sanitizer, which is helpful for development purposes.