### PR TITLE
add proper checks for join/refresh RPC return values

### DIFF
--- a/src/ssg-rpc.c
+++ b/src/ssg-rpc.c
@@ -180,7 +180,7 @@ int ssg_group_join_send(
     }
 
     /* if our initial buffer is too small, reallocate to the exact size & rejoin */
-    while (join_resp.view_buf_size > tmp_view_buf_size)
+    while (join_resp.ret == SSG_ERR_NOBUFS)
     {
         b = realloc(tmp_view_buf, join_resp.view_buf_size);
         if(!b)
@@ -221,7 +221,8 @@ int ssg_group_join_send(
     }
 
     /* readjust view buf size if initial guess was too large */
-    if (join_resp.view_buf_size < tmp_view_buf_size)
+    if ((join_resp.view_buf_size < tmp_view_buf_size) &&
+        (join_resp.ret == SSG_SUCCESS))
     {
         b = realloc(tmp_view_buf, join_resp.view_buf_size);
         if(!b)
@@ -604,7 +605,7 @@ int ssg_group_refresh_send(
     }
 
     /* if our initial buffer is too small, reallocate to the exact size & resend */
-    while (refresh_resp.view_buf_size > tmp_view_buf_size)
+    while (refresh_resp.ret == SSG_ERR_NOBUFS)
     {
         b = realloc(tmp_view_buf, refresh_resp.view_buf_size);
         if(!b)
@@ -645,7 +646,8 @@ int ssg_group_refresh_send(
     }
 
     /* readjust view buf size if initial guess was too large */
-    if (refresh_resp.view_buf_size < tmp_view_buf_size)
+    if ((refresh_resp.view_buf_size < tmp_view_buf_size) &&
+        ((refresh_resp.ret == SSG_SUCCESS)))
     {
         b = realloc(tmp_view_buf, refresh_resp.view_buf_size);
         if(!b)

--- a/tests/ssg-refresh-group.c
+++ b/tests/ssg-refresh-group.c
@@ -27,13 +27,6 @@
         } \
     } while(0)
 
-#include <time.h>
-double my_wtime() {
-    struct timeval time;
-    gettimeofday(&time, NULL);
-    return time.tv_sec + time.tv_usec/1000000.0;
-}
-
 DECLARE_MARGO_RPC_HANDLER(group_id_forward_recv_ult)
 
 static void usage()
@@ -127,9 +120,9 @@ int main(int argc, char *argv[])
 
     /* load group info from file */
     num_addrs = SSG_ALL_MEMBERS;
-    load_time = my_wtime();
+    load_time = ABT_get_wtime();
     sret = ssg_group_id_load(gid_file, &num_addrs, &g_id);
-    load_time = my_wtime() - load_time;
+    load_time = ABT_get_wtime() - load_time;
     DIE_IF(sret != SSG_SUCCESS, "ssg_group_id_load (%s)", ssg_strerror(sret));
     DIE_IF(num_addrs < 1, "ssg_group_id_load (%s)", ssg_strerror(sret));
 
@@ -149,10 +142,10 @@ int main(int argc, char *argv[])
     DIE_IF(sret != SSG_ERR_MID_NOT_FOUND, "ssg_get_group_member_addr (%s)", ssg_strerror(sret));
     DIE_IF(member_addr != HG_ADDR_NULL, "ssg_get_group_member_addr (%s)", ssg_strerror(sret));
 
-    refresh_time = my_wtime();
+    refresh_time = ABT_get_wtime();
     /* refresh the SSG server group view */
     sret = ssg_group_refresh(mid, g_id);
-    refresh_time = my_wtime() - refresh_time;
+    refresh_time = ABT_get_wtime() - refresh_time;
     DIE_IF(sret != SSG_SUCCESS, "ssg_group_refresh (%s)", ssg_strerror(sret));
 
     /* With a large number of clients, having everyone dump their group state


### PR DESCRIPTION
If join/refresh operations fail for some reason on the remote target of the RPC, we need to make sure not to do things at the RPC source (i.e., process trying to join or refresh a group) that should only be done on success (like modify buffer sizes, ultimately leading to segfault mentioned in #64).

Fixes #64.